### PR TITLE
@broskoski: Give option to store asset manifest in the environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ results
 npm-debug.log
 /test/cli.js
 .DS_Store
+manifest.json

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ S3_SECRET=
 
 Run with deploy script
 ````
-heroku config:set COMMIT_HASH=$(shell git rev-parse --short HEAD)
+heroku config:set ASSET_MANIFEST=$(cat manifest.json)
 ````
 
 Set once

--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ module.exports = function(options) {
       next();
     }
   // Setup callbacks so we can queue requets until we've got the manifest.
-  var manifest, opts, manifestErr, manifestCallbacks = [];
+  var manifest, opts, manifestCallbacks = [];
   var onManifestFetched = function(callback) {
     manifestCallbacks.push(callback);
   };
@@ -35,30 +35,35 @@ module.exports = function(options) {
   // Fetch the manifest
   setup(options, function(err, options) {
     opts = options;
-    if (err) return manifestCallback(manifestErr = err);
-    request.get(opts.cdnUrl + '/manifest-' + options.hash + '.json').end(function(err, res) {
-      if (err) return manifestCallback(manifestErr = err);
-      try {
-        manifest = JSON.parse(res.text);
-        manifestCallback();
-      } catch (err) {
-        console.warn(res.text);
-        manifestCallback(manifestErr = err);
-      }
-    });
+    if (err) return manifestCallback(err);
+    request
+      .get(opts.cdnUrl + '/manifest-' + options.hash + '.json')
+      .end(function(err, res) {
+        if (err) return manifestCallback(err);
+        try {
+          manifest = JSON.parse(res.text);
+          manifestCallback();
+        } catch (err) {
+          console.warn(res.text);
+          manifestCallback(err);
+        }
+      });
   });
   // Once the manifest is fetched attach a helper to lookup the file in the
   // manifest or noop. This will prefer .gz/.cgz/.jgz extensioned versions
   // if they exist.
   return function(req, res, next) {
-    if (manifestErr) return next(manifestErr);
-    res.locals.asset = function(filename) {
-      var manifestFile = manifest[filename + '.gz']  ||
-        manifest[filename + '.cgz'] || manifest[filename + '.jgz'] ||
-        manifest[filename];
-      return manifestFile ? opts.cdnUrl + manifestFile : filename;
-    }
-    manifest ? next() : onManifestFetched(next);
+    res.locals.asset = function(filename) { return filename };
+    onManifestFetched(function(err) {
+      if (err) return next(err);
+      res.locals.asset = function(filename) {
+        var manifestFile = manifest[filename + '.gz']  ||
+          manifest[filename + '.cgz'] || manifest[filename + '.jgz'] ||
+          manifest[filename];
+        return manifestFile ? opts.cdnUrl + manifestFile : filename;
+      }
+      next();
+    });
   }
 };
 

--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ var _ = require('underscore');
 var crypto = require('crypto');
 var NODE_ENV = process.env.NODE_ENV;
 var COMMIT_HASH = process.env.COMMIT_HASH;
+var ASSET_MANIFEST = process.env.ASSET_MANIFEST;
 var mime = require('mime');
 var request = require('superagent');
 var async = require('async');
@@ -22,6 +23,10 @@ module.exports = function(options) {
       res.locals.asset = function(filename) { return filename };
       next();
     }
+  // If the manifest is stored in the environment then parse that into our
+  // `asset` helper
+  if (ASSET_MANIFEST)
+    return assetMiddleware(JSON.parse(ASSET_MANIFEST), options.cdnUrl)
   // Setup callbacks so we can queue requets until we've got the manifest.
   var manifest, opts, manifestCallbacks = [];
   var onManifestFetched = function(callback) {
@@ -56,13 +61,7 @@ module.exports = function(options) {
     res.locals.asset = function(filename) { return filename };
     onManifestFetched(function(err) {
       if (err) return next(err);
-      res.locals.asset = function(filename) {
-        var manifestFile = manifest[filename + '.gz']  ||
-          manifest[filename + '.cgz'] || manifest[filename + '.jgz'] ||
-          manifest[filename];
-        return manifestFile ? opts.cdnUrl + manifestFile : filename;
-      }
-      next();
+      else return assetMiddleware(manifest, opts.cdnUrl)(req, res, next);
     });
   }
 };
@@ -98,6 +97,28 @@ module.exports.upload = function(options) {
     });
   });
 };
+
+// Generate middleware that adds the asset helper to locals based on a manifest
+// and CDN url
+//
+// @param {String} manifest object pointing to fingerprinted assets
+// @param {String} CDN url
+// @return {Function}
+
+var assetMiddleware = function(manifest, cdnUrl) {
+  return function(req, res, next) {
+    res.locals.asset = function(filename) {
+      var manifestFile = (
+        manifest[filename + '.gz']  ||
+        manifest[filename + '.cgz'] ||
+        manifest[filename + '.jgz'] ||
+        manifest[filename]
+      );
+      return manifestFile ? cdnUrl + manifestFile : filename;
+    }
+    next();
+  }
+}
 
 // Given a filename determines the proper S3 headers.
 //
@@ -166,6 +187,12 @@ var uploadManifest = function(files, options, callback) {
       callback(err, manifest);
     }
   );
+  try {
+    fs.writeFileSync(
+      process.cwd() + '/manifest.json',
+      JSON.stringify(manifest)
+    );
+  } catch (e) { console.warn("Failed to write manifest.json") };
   return manifest;
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bucket-assets",
-  "version": "0.3.0",
+  "version": "1.0.0",
   "description": "Uploads a folder of static assets to an s3 bucket with convenient assumptions.",
   "keywords": [
     "s3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bucket-assets",
-  "version": "0.2.12",
+  "version": "0.3.0",
   "description": "Uploads a folder of static assets to an s3 bucket with convenient assumptions.",
   "keywords": [
     "s3",

--- a/test/test.js
+++ b/test/test.js
@@ -214,6 +214,17 @@ describe('bucketAssets', function() {
       next.called.should.be.ok;
     });
 
+    it('can pull the manifest from the environment', function() {
+      bucketAssets.__set__('ASSET_MANIFEST', JSON.stringify({
+        '/foo.js': '/foo-123.js',
+        '/foo.js.gz': '/foo-456.js.gz'
+      }));
+      bucketAssets.__set__('NODE_ENV', 'production');
+      bucketAssets({ cdnUrl: 'http://cdn.com' })(req, res, next);
+      res.locals.asset('/foo.js').should.equal('http://cdn.com/foo-456.js.gz');
+      bucketAssets.__set__('ASSET_MANIFEST', null);
+    });
+
     it('fetches the manifest and when finished provides a ' +
        'fingerprinting view helper', function() {
       next.called.should.not.be.ok

--- a/test/test.js
+++ b/test/test.js
@@ -239,7 +239,16 @@ describe('bucketAssets', function() {
       bucketAssets({ cdnUrl: 'http://cdn.com' })(req, res, next);
       endStub.args[0][0](null, { text: "<error>Thanks for the XML!</error>" });
       next.args[0][0].toString()
-        .should.equal('SyntaxError: Unexpected token <');
+        .should.containEql('SyntaxError: Unexpected token <');
+    });
+
+    it('noops when failing to fetch from S3', function(done) {
+      bucketAssets.__set__('NODE_ENV', 'production');
+      bucketAssets({ cdnUrl: 'http://cdn.com' })(req, res, (err) => {
+        res.locals.asset('/foo.js').should.equal('/foo.js');
+        done();
+      });
+      endStub.args[0][0](new Error('Fail'));
     });
 
     it('tries to find the manifest by git hash', function() {


### PR DESCRIPTION
This adds a step that writes the manifest file to local disk so one can use `heroku config:set ASSET_MANIFEST= $(cat manifest.json)` to add it as an environment variable in their CI step. This will allow us to avoid having to download the asset manifest on startup and circumvent [this](https://github.com/artsy/post_mortems/issues/10) from happening. I also let a failed manifest fetch fall back to pointing to local assets, but ideally, this would be combined with [some amount of retries](https://github.com/visionmedia/superagent/pull/1155).